### PR TITLE
Add typo rule for "macOS"

### DIFF
--- a/rules/typo.yml
+++ b/rules/typo.yml
@@ -4,6 +4,11 @@
   pass: GitHub
   justification: When it means a third-party identifier (e.g., X-Github-Media-Type).
 
+- id: review.sider.typo.macos
+  pattern: MacOS
+  message: Is this a typo for "macOS"?
+  pass: macOS
+
 - id: review.sider.typo.javascript
   pattern: Javascript
   message: Is this a typo for "JavaScript"?


### PR DESCRIPTION
https://www.apple.com/macos/