### PR TITLE
Add typo rule for "website"

### DIFF
--- a/rules/typo.yml
+++ b/rules/typo.yml
@@ -135,6 +135,15 @@
   message: Is this a typo for "stylelint"?
   pass: stylelint
 
+- id: review.sider.typo.website
+  pattern:
+    literal: "web site"
+    case_sensitive: false
+  message: Is this a typo for "Website" or "website"?
+  pass:
+    - Website
+    - website
+
 - id: review.sider.typo.sider
   pattern: Cider
   message: Is this a typo for "Sider"?


### PR DESCRIPTION
See also [Web site vs. website – Correct Spelling – Grammarist](https://grammarist.com/spelling/web-site-website/)