### PR TITLE
Add typo rule for "MinIO"

### DIFF
--- a/rules/typo.yml
+++ b/rules/typo.yml
@@ -211,6 +211,12 @@
     - Sleeek
     - sleeek
 
+- id: review.sider.typo.minio
+  pattern:
+    - Minio
+  message: Is this a typo for "MinIO"?
+  pass: MinIO
+
 - id: review.sider.typo.japanese.count_months
   pattern: ヶ月
   message: |


### PR DESCRIPTION
https://min.io/

See also https://github.com/sider/sider-docs/pull/446#issuecomment-648556378