### PR TITLE
Add rule for default branch on GitHub Actions

### DIFF
--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -1,6 +1,7 @@
 rules: []
 
 import:
-  - rules/typo.yml
+  - rules/github.yml
   - rules/ruby.yml
+  - rules/typo.yml
   - rules/web.yml

--- a/rules/github.yml
+++ b/rules/github.yml
@@ -1,0 +1,14 @@
+- id: sider.goodcheck-rules.github.actions.default-branch
+  pattern:
+    - master
+  glob:
+    - "**/.github/workflows/**/*.yml"
+  message: |
+    Use `$default-branch` instead of a hard-coded default branch name such as `master`
+
+    In the future, many repositories may no longer use `master` as the default branch name.
+    See also the following announcement:
+    https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/
+  justification:
+    - When this is not a branch name.
+    - When this usage of the branch name is reasonable.


### PR DESCRIPTION
See https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/