### PR TITLE
Add rule about deprecated commands of GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For more details, please see [the Goodcheck documentation](https://github.com/si
 - [Typo](rules/typo.yml)
 - [Ruby](rules/ruby.yml)
 - [Web](rules/web.yml)
+- [GitHub](rules/github.yml)
 
 ## License
 

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -4,3 +4,4 @@ import:
   - rules/typo.yml
   - rules/ruby.yml
   - rules/web.yml
+  - rules/github.yml

--- a/rules/github.yml
+++ b/rules/github.yml
@@ -1,0 +1,14 @@
+- id: sider.goodcheck-rules.github.actions.disallow-set-env-and-add-path
+  pattern:
+    - "set-env"
+    - "add-path"
+  glob:
+    - ".github/workflows/*.yml"
+  message: |
+    Disallow `set-env` and `add-path` commands in workflows of GitHub Actions.
+
+    These commands have been deprecated for the following security reason:
+    https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
+
+    You can rewrite the commands with "Environment Files":
+    https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files


### PR DESCRIPTION
See <https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/>